### PR TITLE
Fixed index loading

### DIFF
--- a/flask_taxonomies_es/api.py
+++ b/flask_taxonomies_es/api.py
@@ -1,6 +1,6 @@
-import time
 from datetime import datetime
 
+import time
 from elasticsearch_dsl import Search, Q
 from flask_taxonomies.models import TaxonomyTerm
 from invenio_search import current_search_client
@@ -18,17 +18,19 @@ class TaxonomyESAPI:
 
     def __init__(self, app):
         self.app = app
-        self.index = app.config["TAXONOMY_ELASTICSEARCH_INDEX"]
-        self._create_index()
+        # self.index = app.config["TAXONOMY_ELASTICSEARCH_INDEX"]
+        # self._create_index()
 
-    def _create_index(self):
-        with self.app.app_context():
-            if not current_search_client.indices.exists(self.index):
-                current_search_client.indices.create(
-                    index=self.index,
-                    ignore=400,
-                    body={}
-                )
+    @property
+    def index(self):
+        _index = self.app.config["TAXONOMY_ELASTICSEARCH_INDEX"]
+        if not current_search_client.indices.exists(_index):
+            current_search_client.indices.create(
+                index=_index,
+                ignore=400,
+                body={}
+            )
+        return _index
 
     def set(self, taxonomy_term: TaxonomyTerm, timestamp=None) -> None:
         """

--- a/flask_taxonomies_es/cli.py
+++ b/flask_taxonomies_es/cli.py
@@ -1,5 +1,5 @@
 import click
-from flask import cli
+from flask import cli, current_app
 from flask_taxonomies.cli import taxonomies
 from flask_taxonomies.models import Taxonomy
 
@@ -54,4 +54,6 @@ def list_(taxonomy: str):
 @es.command("reindex")
 @cli.with_appcontext
 def list_():
-    current_flask_taxonomies_es.reindex()
+    api = current_app.wsgi_app.mounts['/api']
+    with api.app_context():
+        current_flask_taxonomies_es.reindex()

--- a/setup.py
+++ b/setup.py
@@ -64,54 +64,12 @@ setup(
     zip_safe=False,
     packages=['flask_taxonomies_es'],
     entry_points={
-        # TODO: zrevidovat EP
-        # 'invenio_db.models': [
-        #     'flask_taxonomies = flask_taxonomies.models',
-        # ],
-        # 'invenio_db.alembic': [
-        #     'flask_taxonomies = flask_taxonomies:alembic',
-        # ],
-        # 'invenio_base.api_blueprints': [
-        #     'flask_taxonomies = flask_taxonomies.views:blueprint',
-        # ],
         'invenio_base.apps': [
             'flask_taxonomies = flask_taxonomies_es.ext:FlaskTaxonomiesES',
         ],
-        # 'invenio_base.api_apps': [
-        #     'flask_taxonomies = flask_taxonomies.ext:FlaskTaxonomies',
-        #     'flask_taxonomies_redis = flask_taxonomies.redis.ext:FlaskTaxonomiesRedis',
-        # ],
-        # 'invenio_jsonschemas.schemas': [
-        #     'flask_taxonomies = flask_taxonomies.jsonschemas'
-        # ],
-        # 'invenio_oarepo_mapping_includes': [
-        #     'flask_taxonomies=flask_taxonomies.included_mappings'
-        # ],
-        # 'invenio_records.jsonresolver': [
-        #     'flask_taxonomies = flask_taxonomies.jsonresolver'
-        # ],
-        # 'invenio_access.actions': [
-        #     # Taxonomy related permissions
-        #     'taxonomy_create_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_create_all',
-        #     'taxonomy_read_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_read_all',
-        #     'taxonomy_update_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_update_all',
-        #     'taxonomy_delete_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_delete_all',
-        #     # Taxonomy term related permissions.
-        #     'taxonomy_term_create_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_term_create_all',
-        #     'taxonomy_term_read_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_term_read_all',
-        #     'taxonomy_term_update_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_term_update_all',
-        #     'taxonomy_term_delete_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_term_delete_all',
-        #     'taxonomy_term_move_all'
-        #     ' = flask_taxonomies.permissions:taxonomy_term_move_all',
-        # ],
+        'invenio_base.api_apps': [
+            'flask_taxonomies = flask_taxonomies_es.ext:FlaskTaxonomiesES',
+        ],
         'flask.commands': [
             'taxonomies_es = flask_taxonomies_es.cli:taxonomies',
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,8 @@ def app():
 
     shutil.rmtree(instance_path)
     with _app.app_context():
-        current_search_client.indices.delete(index=_app.config["TAXONOMY_ELASTICSEARCH_INDEX"])
+        if current_search_client.indices.exists(_app.config["TAXONOMY_ELASTICSEARCH_INDEX"]):
+            current_search_client.indices.delete(index=_app.config["TAXONOMY_ELASTICSEARCH_INDEX"])
 
 
 # @pytest.yield_fixture()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,14 +4,9 @@ from pprint import pprint
 
 import pytest
 import time
-from invenio_search import current_search_client
 
 from flask_taxonomies_es.exceptions import InvalidTermIdentification
 from flask_taxonomies_es.proxies import current_flask_taxonomies_es
-
-
-def test_init(app):
-    assert current_search_client.indices.exists(app.config["TAXONOMY_ELASTICSEARCH_INDEX"])
 
 
 def test_set_get_remove(app, db, root_taxonomy, sample_term):

--- a/tests/test_flask_taxonomies.py
+++ b/tests/test_flask_taxonomies.py
@@ -11,12 +11,11 @@ def test_version():
 
 
 # TODO: vyřešit problém s current_search_client, aplikace potřebuje znát adresu elastiku
-@pytest.mark.skip(
-    reason="The test needs to resolve the dependency on invenio-search and its "
-           "current_search_client.")
+# @pytest.mark.skip(
+#     reason="The test needs to resolve the dependency on invenio-search and its "
+#            "current_search_client.")
 def test_init():
     """Test extension initialization."""
-    print("start")
     app = Flask('testapp')
     ext = FlaskTaxonomiesES(app)
     assert 'flask-taxonomies-es' in app.extensions


### PR DESCRIPTION
The index was loaded at initialization. However, an ES client that provides invenio-search is required to retrieve the index. If flask-taxonomies-es was initialized before invenio-search, it caused errors. Now the index is called lazily as a getter.